### PR TITLE
ruby 1.8.7 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.9.1
+
+* Ruby 1.8.7 fix
+
 ## 1.2.9
 
 * Add support for dockerized metric gathering

--- a/lib/server_metrics/system_info.rb
+++ b/lib/server_metrics/system_info.rb
@@ -45,7 +45,7 @@ module ServerMetrics
 
     # When run inside a docker container, we want to read from the host proc dir. 
     def self.proc_dir
-      @@proc_dir ||= (Dir.exist?("/host/proc") ? "/host/proc" : "/proc")
+      @@proc_dir ||= (File.directory?("/host/proc") ? "/host/proc" : "/proc")
     end
   end
 end

--- a/lib/server_metrics/version.rb
+++ b/lib/server_metrics/version.rb
@@ -1,3 +1,3 @@
 module ServerMetrics
-  VERSION = '1.2.9'
+  VERSION = '1.2.9.1'
 end


### PR DESCRIPTION
`Dir#exist?` doesn't exist in Ruby 1.8.7. Using `File#directory?` instead.